### PR TITLE
Python: Add 'requirements.txt'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,6 @@ Install the necessary Python packages:
 pip install -r requirements.txt
 ```
 
-If you don't have a `requirements.txt` file, you can install the required packages individually:
-
-```bash
-pip install requests click
-```
-
 ### 3. Make the Script Executable
 
 Make sure the `plog.py` script is executable:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2024.8.30
+charset-normalizer==3.4.0
+click==8.1.7
+idna==3.10
+requests==2.32.3
+urllib3==2.2.3


### PR DESCRIPTION
This file is usually added to versioning as well, so we can get rid of "if you don't have a requirements.txt" in the README file.